### PR TITLE
Update composer.json to work with php 5.5+ and 7.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         "learninglocker/statementfactory": "~0.0"
     },
     "require": {
-        "rusticisoftware/tincan": "0.40.0",
+        "rusticisoftware/tincan": "~1.0 as 0.12.0",
         "learninglocker/moodle-log-expander": "~1.1",
         "learninglocker/moodle-xapi-translator": "~1.1",
         "learninglocker/xapi-recipe-emitter": "~1.1"


### PR DESCRIPTION
Couldn't load master with a php 5.5+ or php 7.0 server, but by upgrading tincan to 1.0.0 and allowing it to appear to be 0.12.0 this seems to resolve the dependencies and work.